### PR TITLE
feat(grounding): add mixture-of-grounding fallback to generate_coords

### DIFF
--- a/gui_agents/s2/agents/grounding.py
+++ b/gui_agents/s2/agents/grounding.py
@@ -335,8 +335,8 @@ class OSWorldACI(ACI):
             self.coords2 = self.mixture_generate_coords(args[1], obs) # use mixture fallback for both endpoints
         # arg0 and arg1 are text phrases
         elif function_name == "agent.highlight_text_span" and len(args) >= 2:
-            self.coords1 = self.generate_text_coords(args[0], obs, alignment="start") # use mixture fallback for both endpoints
-            self.coords2 = self.generate_text_coords(args[1], obs, alignment="end") # use mixture fallback for both endpoints
+            self.coords1 = self.generate_text_coords(args[0], obs, alignment="start")
+            self.coords2 = self.generate_text_coords(args[1], obs, alignment="end") 
 
     # Resize from grounding model dim into OSWorld dim (1920 * 1080)
     def resize_coordinates(self, coordinates: List[int]) -> List[int]:

--- a/gui_agents/s2/agents/grounding.py
+++ b/gui_agents/s2/agents/grounding.py
@@ -328,7 +328,7 @@ class OSWorldACI(ACI):
             and len(args) >= 1
             and args[0] != None
         ):
-            self.coords1 = self.mixture_generate_coords(args[0], obs) #use mixture fallback for both endpoints
+            self.coords1 = self.mixture_generate_coords(args[0], obs) # use mixture fallback for more reliable coordinate lookup
         # arg0 and arg1 are descriptions
         elif function_name == "agent.drag_and_drop" and len(args) >= 2:
             self.coords1 = self.mixture_generate_coords(args[0], obs) # use mixture fallback for both endpoints


### PR DESCRIPTION
- Introduce `mixture_generate_coords` that first tries LLM-based grounding and falls back to OCR on failure for more robust coordinate lookup
- Update `assign_coordinates` to use the new mixture method for click and drag-and-drop actions

This improves resilience when the primary grounding model cannot locate elements.  