### PR TITLE
Fix AttributeError: 'Namespace' object has no attribute 'model_provider'

### DIFF
--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -219,7 +219,7 @@ def main():
 
     # Load the general engine params
     engine_params = {
-        "engine_type": args.model_provider,
+        "engine_type": args.provider,
         "model": args.model,
         "base_url": args.model_url,
         "api_key": args.model_api_key,


### PR DESCRIPTION
Fixed this:
```
Traceback (most recent call last):
  File "/config/Desktop/Agent-S/./gui_agents/s2/cli_app.py", line 276, in <module>
    main()
  File "/config/Desktop/Agent-S/./gui_agents/s2/cli_app.py", line 222, in main
    "engine_type": args.model_provider,
                   ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'model_provider'
