### PR TITLE
fix OpenRouter add_message()

### DIFF
--- a/gui_agents/s2/core/mllm.py
+++ b/gui_agents/s2/core/mllm.py
@@ -124,6 +124,7 @@ class LMMAgent:
                 LMMEngineAzureOpenAI,
                 LMMEngineHuggingFace,
                 LMMEngineGemini,
+                LMMEngineOpenRouter,
             ),
         ):
             # infer role from previous message
@@ -263,6 +264,8 @@ class LMMAgent:
                     )
 
             self.messages.append(message)
+        else:
+            raise ValueError("engine_type is not supported")
 
     def get_response(
         self,


### PR DESCRIPTION
- Fixed DAG generation for OpenRouter (it sent the instructions without the plan)
- Added an error to be thrown, instead of silently skipping add_message()