### PR TITLE
Add grounding model height option

### DIFF
--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -185,6 +185,12 @@ def main():
         default=1366,
         help="Width of screenshot image after processor rescaling",
     )
+    parser.add_argument(
+        "--grounding_model_resize_height",
+        type=int,
+        default=None,
+        help="Height of screenshot image after processor rescaling",
+    )
 
     # Grounding model config option 2: Self-hosted endpoint based
     parser.add_argument(
@@ -233,13 +239,16 @@ def main():
             "api_key": args.endpoint_api_key,
         }
     else:
+        grounding_height = args.grounding_model_resize_height
+        # If not provided, use the aspect ratio of the screen to compute the height
+        if grounding_height is None:
+            grounding_height = screen_height * args.grounding_model_resize_width / screen_width
+
         engine_params_for_grounding = {
             "engine_type": args.grounding_model_provider,
             "model": args.grounding_model,
             "grounding_width": args.grounding_model_resize_width,
-            "grounding_height": screen_height
-            * args.grounding_model_resize_width
-            / screen_width,
+            "grounding_height": grounding_height,
         }
 
     grounding_agent = OSWorldACI(

--- a/osworld_setup/s2/run.py
+++ b/osworld_setup/s2/run.py
@@ -133,6 +133,12 @@ def config() -> argparse.Namespace:
         default=1366,
         help="Width of screenshot image after processor rescaling",
     )
+    parser.add_argument(
+        "--grounding_model_resize_height",
+        type=int,
+        default=None,
+        help="Height of screenshot image after processor rescaling",
+    )
 
     # Configuration 2
     parser.add_argument("--endpoint_provider", type=str, default="")
@@ -190,13 +196,16 @@ def test(args: argparse.Namespace, test_all_meta: dict) -> None:
             "api_key": args.endpoint_api_key,
         }
     else:
+        grounding_height = args.grounding_model_resize_height
+        # If not provided, use the aspect ratio of the screen to compute the height
+        if grounding_height is None:
+            grounding_height = args.screen_height * args.grounding_model_resize_width / args.screen_width
+
         engine_params_for_grounding = {
             "engine_type": args.grounding_model_provider,
             "model": args.grounding_model,
             "grounding_width": args.grounding_model_resize_width,
-            "grounding_height": args.screen_height
-            * args.grounding_model_resize_width
-            / args.screen_width,
+            "grounding_height": grounding_height,
         }
 
     # NEW!


### PR DESCRIPTION
This allows users to set `--grounding_model_resize_height`. It defaults to the same calculated value if not set.

I added this option to allow fixed height values like 1000 for Gemini. (https://github.com/simular-ai/Agent-S/issues/91)

Example usage:
```
./bin/python ./gui_agents/s2/cli_app.py \
  --provider "open_router" \
  --model "google/gemini-2.5-flash-preview-05-20" \
  --grounding_model_provider "open_router" \
  --grounding_model "google/gemini-2.5-flash-preview-05-20" \
  --grounding_model_resize_width=1000 \
  --grounding_model_resize_height=1000
```