### PR TITLE
Implement a Ctrl+C signal handler to pause for debug purposes

### DIFF
--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -7,9 +7,7 @@ import platform
 import pyautogui
 import signal
 import sys
-import termios
 import time
-import tty
 
 from PIL import Image
 
@@ -24,14 +22,22 @@ paused = False
 def get_char():
     """Get a single character from stdin without pressing Enter"""
     try:
-        fd = sys.stdin.fileno()
-        old_settings = termios.tcgetattr(fd)
-        try:
-            tty.setraw(sys.stdin.fileno())
-            ch = sys.stdin.read(1)
-        finally:
-            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-        return ch
+        # Import termios and tty on Unix-like systems
+        if platform.system() in ["Darwin", "Linux"]:
+            import termios
+            import tty
+            fd = sys.stdin.fileno()
+            old_settings = termios.tcgetattr(fd)
+            try:
+                tty.setraw(sys.stdin.fileno())
+                ch = sys.stdin.read(1)
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+            return ch
+        else:
+            # Windows fallback
+            import msvcrt
+            return msvcrt.getch().decode('utf-8', errors='ignore')
     except:
         return input()  # Fallback for non-terminal environments
 

--- a/gui_agents/s2_5/cli_app.py
+++ b/gui_agents/s2_5/cli_app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import pyautogui
+import signal
 import sys
 import time
 
@@ -14,6 +15,71 @@ from gui_agents.s2_5.agents.grounding import OSWorldACI
 from gui_agents.s2_5.agents.agent_s import AgentS2_5
 
 current_platform = platform.system().lower()
+
+# Global flag to track pause state for debugging
+paused = False
+
+def get_char():
+    """Get a single character from stdin without pressing Enter"""
+    try:
+        # Import termios and tty on Unix-like systems
+        if platform.system() in ["Darwin", "Linux"]:
+            import termios
+            import tty
+            fd = sys.stdin.fileno()
+            old_settings = termios.tcgetattr(fd)
+            try:
+                tty.setraw(sys.stdin.fileno())
+                ch = sys.stdin.read(1)
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+            return ch
+        else:
+            # Windows fallback
+            import msvcrt
+            return msvcrt.getch().decode('utf-8', errors='ignore')
+    except:
+        return input()  # Fallback for non-terminal environments
+
+def signal_handler(signum, frame):
+    """Handle Ctrl+C signal for debugging during agent execution"""
+    global paused
+    
+    if not paused:
+        print("\n\n🔸 Agent-S Workflow Paused 🔸")
+        print("=" * 50)
+        print("Options:")
+        print("  • Press Ctrl+C again to quit")
+        print("  • Press Esc to resume workflow")
+        print("=" * 50)
+        
+        paused = True
+        
+        while paused:
+            try:
+                print("\n[PAUSED] Waiting for input... ", end="", flush=True)
+                char = get_char()
+                
+                if ord(char) == 3:  # Ctrl+C
+                    print("\n\n🛑 Exiting Agent-S...")
+                    sys.exit(0)
+                elif ord(char) == 27:  # Esc
+                    print("\n\n▶️  Resuming Agent-S workflow...")
+                    paused = False
+                    break
+                else:
+                    print(f"\n   Unknown command: '{char}' (ord: {ord(char)})")
+                    
+            except KeyboardInterrupt:
+                print("\n\n🛑 Exiting Agent-S...")
+                sys.exit(0)
+    else:
+        # Already paused, second Ctrl+C means quit
+        print("\n\n🛑 Exiting Agent-S...")
+        sys.exit(0)
+
+# Set up signal handler for Ctrl+C
+signal.signal(signal.SIGINT, signal_handler)
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -81,10 +147,14 @@ def scale_screen_dimensions(width: int, height: int, max_dim_size: int):
 
 
 def run_agent(agent, instruction: str, scaled_width: int, scaled_height: int):
+    global paused
     obs = {}
     traj = "Task:\n" + instruction
     subtask_traj = ""
-    for _ in range(15):
+    for step in range(15):
+        # Check if we're in paused state and wait
+        while paused:
+            time.sleep(0.1)
         # Get screen shot using pyautogui
         screenshot = pyautogui.screenshot()
         screenshot = screenshot.resize((scaled_width, scaled_height), Image.LANCZOS)
@@ -98,6 +168,12 @@ def run_agent(agent, instruction: str, scaled_width: int, scaled_height: int):
         # Convert to base64 string.
         obs["screenshot"] = screenshot_bytes
 
+        # Check again for pause state before prediction
+        while paused:
+            time.sleep(0.1)
+
+        print(f"\n🔄 Step {step + 1}/15: Getting next action from agent...")
+        
         # Get next action code from the agent
         info, code = agent.predict(instruction=instruction, observation=obs)
 
@@ -117,12 +193,17 @@ def run_agent(agent, instruction: str, scaled_width: int, scaled_height: int):
             continue
 
         if "wait" in code[0].lower():
+            print("⏳ Agent requested wait...")
             time.sleep(5)
             continue
 
         else:
             time.sleep(1.0)
             print("EXECUTING CODE:", code[0])
+
+            # Check for pause state before execution
+            while paused:
+                time.sleep(0.1)
 
             # Ask for permission before executing
             exec(code[0])


### PR DESCRIPTION
### Overview
This PR adds a Ctrl+C signal handler to Agent-S that enables debugging and workflow control during agent execution.

### Files Modified
**1. Signal Handler (cli_app.py)**
- Press `Ctrl+C` during agent execution to pause the workflow
- Debugging interface with simple options:
  - `Ctrl+C` again to quit
  - `Esc` to resume workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an interactive pause-and-resume debugging feature for agent workflows, allowing users to pause execution with Ctrl+C, resume with Esc, or quit with a second Ctrl+C.
  * Added clear on-screen prompts and step progress indicators during agent execution.
  * Improved user control over workflow interruption and resumption directly from the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->