### PR TITLE
Fixed `open` action for Windows desktop.

### DIFF
--- a/gui_agents/s2_5/agents/grounding.py
+++ b/gui_agents/s2_5/agents/grounding.py
@@ -400,7 +400,7 @@ class OSWorldACI(ACI):
 
     @agent_action
     def open(self, app_or_filename: str):
-        """Open any application or file with name app_or_filename. Use this action to open applications or files on the desktop, do not open manually.
+        """Open any application or file with name app_or_filename. This action should be used on Linux/Darwin systems instead of opening the file manually. Do not use on Windows.
         Args:
             app_or_filename:str, the name of the application or filename to open
         """


### PR DESCRIPTION
Fixed grammatical errors in the original prompt and added a warning for Windows systems. 

The original one may break the whole system, because the execution results from the `open` action are None, without throwing any exceptions. This results in an unhandled error:
`exec() arg 1 must be a string, bytes or code object`  at 
https://github.com/simular-ai/Agent-S/blob/52c02609e3575784c28486757c270606cae9fc7e/gui_agents/s2_5/cli_app.py#L128
This is because `code[0]` here will be `None`. The new prompt fixes the issue.