### PR TITLE
fix: make OSWorldACI env optional, prevent crashes in local CLI runs,…

### DIFF
--- a/gui_agents/s3/agents/grounding.py
+++ b/gui_agents/s3/agents/grounding.py
@@ -179,7 +179,8 @@ set_cell_values(new_cell_values={cell_values}, app_name="{app_name}", sheet_name
 class OSWorldACI(ACI):
     def __init__(
         self,
-        env,
+        env=None,
+        *,
         platform: str,
         engine_params_for_generation: Dict,
         engine_params_for_grounding: Dict,
@@ -563,13 +564,29 @@ class OSWorldACI(ACI):
             logger.info(f"Executing FULL TASK: {task_to_execute}")
 
         if task_to_execute:
+            controller = getattr(self.env, "controller", None) if self.env else None
+
+            if controller is None:
+                logger.warning(
+                    "Environment controller unavailable; skipping code agent execution."
+                )
+                self.last_code_agent_result = {
+                    "task_instruction": task_to_execute,
+                    "completion_reason": "NO_ENV_CONTROLLER",
+                    "summary": "Code agent execution skipped because no environment controller was provided.",
+                    "execution_history": [],
+                    "steps_executed": 0,
+                    "budget": self.code_agent.budget,
+                }
+                return "import time; time.sleep(1)"
+
             print("obs keys: ", self.obs.keys())
             screenshot = self.obs.get("screenshot", "") if self.obs else ""
             logger.info(f"Screenshot available: {'Yes' if screenshot else 'No'}")
 
             logger.info("Executing code agent...")
             result = self.code_agent.execute(
-                task_to_execute, screenshot, self.env.controller
+                task_to_execute, screenshot, controller
             )
 
             # Store the result for the worker to access


### PR DESCRIPTION
#  Background
When running `agent_s` locally, the CLI instantiates `OSWorldACI` **without passing an environment**.  
The old constructor required `env` as a **positional argument**, causing the CLI to raise a `TypeError`.

Even if you hacked around that, the code agent still attempted to call `self.env.controller`.  
Without an environment, this triggered an `AttributeError`, making local debugging **basically unusable**.

---

#  Changes
- **Updated `OSWorldACI.__init__`**
  - `env` now defaults to `None`.
  - Remaining parameters must be provided by **keyword**, matching how the class is used in both the CLI and the documentation.

- **Added a guard in `call_code_agent`**
  - If there’s **no environment or controller**, we:
    - Skip code-agent execution.
    - Emit a **warning**.
    - Stash a structured `"skipped"` result in `last_code_agent_result`.
    - Fall back to a simple **wait snippet** instead of crashing.

---

#  Impact

###  Local / CLI runs
- You can now launch the agent **without supplying `env`**.
- UI actions work as expected.
- The code agent is cleanly skipped with clear logging (no crash).

###  OSWorld / Automated runs
- These flows already pass `env=DesktopEnv(...)`, so behavior is **unchanged**.
- The new guard simply makes the code more **resilient** if the environment fails to initialize.

### Diagnostics
- Missing controllers now show up **explicitly in logs** and in the stored results.
- This improves **post-mortem debugging** visibility.

---

#  Notes
- No dependencies or external APIs were modified.  
- Improves local development stability and debugging transparency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds a graceful fallback when the environment is unavailable, returning a brief idle step instead of executing.
  * Introduces safeguards to short-circuit cleanly when no task is provided.
  * Enhances logging with detailed execution outcomes (reason, steps, summary).

* **Bug Fixes**
  * Reduces brittleness by using a derived controller reference, preventing failures when the controller is absent.

* **Refactor**
  * Updates the public constructor: environment is now optional by default, and subsequent parameters are keyword-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->