### PR TITLE
Support passing query message as command line argument

### DIFF
--- a/gui_agents/s3/cli_app.py
+++ b/gui_agents/s3/cli_app.py
@@ -372,24 +372,26 @@ def main():
         max_trajectory_length=args.max_trajectory_length,
         enable_reflection=args.enable_reflection,
     )
+
     task = args.task
-    if task is None or not isinstance(task, str) or len(task.strip())==0:
-        while True:
-            query = input("Query: ")
 
-            agent.reset()
-
-            # Run the agent on your own device
-            run_agent(agent, query, scaled_width, scaled_height)
-
-            response = input("Would you like to provide another query? (y/n): ")
-            if response.lower() != "y":
-                break
-    else:
+    # handle query from command line
+    if isinstance(task, str) and task.strip():
         agent.reset()
-        
+        run_agent(agent, query, scaled_width, scaled_height)
+        return
+
+    while True:
+        query = input("Query: ")
+
+        agent.reset()
+
         # Run the agent on your own device
-        run_agent(agent, task, scaled_width, scaled_height)
+        run_agent(agent, query, scaled_width, scaled_height)
+
+        response = input("Would you like to provide another query? (y/n): ")
+        if response.lower() != "y":
+            break
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add '--task' argument for s3 agent cli, compatible with the old parrameters. The agent will be called once with the argument as its query if the '--task' parameter is given. It's for scripting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option (--task) to accept a single task on launch and run it non-interactively.
  * When a task is provided, the application prepares the session, executes the task, and exits; when omitted, existing interactive behavior is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->