### PR TITLE
chore: Update setup.py version to 0.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gui-agents",
-    version="0.3.1",
+    version="0.3.2",
     description="A library for creating general purpose GUI agents using multimodal LLMs.",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I noticed that the version in `setup.py` is still `0.3.1`, but the latest git tag is `v0.3.2`.
This PR bumps the version in `setup.py` to match the latest release tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.3.2 (patch release)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->