### PR TITLE
fix: replace 42 bare excepts with except Exception

### DIFF
--- a/gui_agents/s1/aci/LinuxOSACI.py
+++ b/gui_agents/s1/aci/LinuxOSACI.py
@@ -344,7 +344,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
     def find_element(self, element_id):
         try:
             selected_element = self.nodes[int(element_id)]
-        except:
+        except Exception:
             print("The index of the selected element was out of range.")
             selected_element = self.nodes[0]
             self.index_out_of_range_flag = True
@@ -414,7 +414,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
         try:
             # Use the provided element_id or default to None
             node = self.find_element(element_id) if element_id is not None else None
-        except:
+        except Exception:
             node = None
 
         if node is not None:
@@ -516,7 +516,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
         """
         try:
             node = self.find_element(element_id)
-        except:
+        except Exception:
             node = self.find_element(0)
         # print(node.attrib)
         coordinates = eval(
@@ -669,7 +669,7 @@ def _create_atspi_node(
         ]:
             try:
                 attribute_dict[f"{value_key}{attr_name}"] = str(attr_func())
-            except:
+            except Exception:
                 pass
     except NotImplementedError:
         pass
@@ -748,7 +748,7 @@ def _create_atspi_node(
                     logger.warning("Max width reached")
                     break
                 xml_node.append(_create_atspi_node(ch, depth + 1, flag))
-        except:
+        except Exception:
             logger.warning(
                 "Error occurred during children traversing. Has Ignored. Node: %s",
                 lxml.etree.tostring(xml_node, encoding="unicode"),

--- a/gui_agents/s1/aci/MacOSACI.py
+++ b/gui_agents/s1/aci/MacOSACI.py
@@ -308,7 +308,7 @@ class MacOSACI(ACI):
         try:
             # Use the provided element_id or default to None
             node = self.find_element(element_id) if element_id is not None else None
-        except:
+        except Exception:
             node = None
 
         if node is not None:
@@ -402,7 +402,7 @@ class MacOSACI(ACI):
         """
         try:
             node = self.find_element(element_id)
-        except:
+        except Exception:
             node = self.find_element(0)
         # print(node.attrib)
         coordinates = node["position"]

--- a/gui_agents/s1/aci/WindowsOSACI.py
+++ b/gui_agents/s1/aci/WindowsOSACI.py
@@ -302,7 +302,7 @@ class WindowsACI(ACI):
         """
         try:
             node = self.find_element(element_id) if element_id is not None else None
-        except:
+        except Exception:
             node = None
 
         if node is not None:
@@ -386,7 +386,7 @@ class WindowsACI(ACI):
         """
         try:
             node = self.find_element(element_id)
-        except:
+        except Exception:
             node = self.find_element(0)
 
         coordinates = node["position"]

--- a/gui_agents/s1/aci/windowsagentarena/GroundingAgent.py
+++ b/gui_agents/s1/aci/windowsagentarena/GroundingAgent.py
@@ -307,7 +307,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
     def find_element(self, element_id):
         try:
             selected_element = self.nodes[int(element_id)]
-        except:
+        except Exception:
             print("The index of the selected element was out of range.")
             selected_element = self.nodes[0]
             self.index_out_of_range_flag = True
@@ -375,7 +375,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
         try:
             # Use the provided element_id or default to None
             node = self.find_element(element_id) if element_id is not None else None
-        except:
+        except Exception:
             node = None
 
         if node is not None:
@@ -432,7 +432,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
     #     '''
     #     try:
     #         node = self.find_element(element_id)
-    #     except:
+    #     except Exception:
     #         node = self.find_element(0)
     #     # print(node.attrib)
     #     coordinates = eval(
@@ -457,7 +457,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
     #     '''
     #     try:
     #         node = self.find_element(element_id)
-    #     except:
+    #     except Exception:
     #         node = self.find_element(0)
 
     #     self.clipboard = node.text
@@ -471,7 +471,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
     #     '''
     #     try:
     #         node = self.find_element(element_id)
-    #     except:
+    #     except Exception:
     #         node = self.find_element(0)
 
     #     coordinates = eval(
@@ -547,7 +547,7 @@ subprocess.run(['wmctrl', '-ir', window_id, '-b', 'add,maximized_vert,maximized_
         """
         try:
             node = self.find_element(element_id)
-        except:
+        except Exception:
             node = self.find_element(0)
         # print(node.attrib)
         coordinates = eval(

--- a/gui_agents/s1/cli_app.py
+++ b/gui_agents/s1/cli_app.py
@@ -39,7 +39,7 @@ def get_char():
             import msvcrt
 
             return msvcrt.getch().decode("utf-8", errors="ignore")
-    except:
+    except Exception:
         return input()  # Fallback for non-terminal environments
 
 

--- a/gui_agents/s1/core/AgentS.py
+++ b/gui_agents/s1/core/AgentS.py
@@ -305,7 +305,7 @@ class GraphSearchAgent(UIAgent):
             )
             try:
                 reflections = json.load(open(reflection_path))
-            except:
+            except Exception:
                 reflections = {}
 
             if self.search_query not in reflections:
@@ -344,7 +344,7 @@ class GraphSearchAgent(UIAgent):
                         self.local_kb_path, self.platform, "episodic_memory.json"
                     )
                     kb = json.load(open(subtask_path))
-                except:
+                except Exception:
                     kb = {}
                 if subtask_key not in kb.keys():
                     subtask_summarization = self.planner.summarize_episode(

--- a/gui_agents/s1/core/Knowledge.py
+++ b/gui_agents/s1/core/Knowledge.py
@@ -82,7 +82,7 @@ class KnowledgeBase(BaseModule):
         try:
             with open(query_path, "r") as f:
                 formulate_query = json.load(f)
-        except:
+        except Exception:
             formulate_query = {}
 
         if instruction in formulate_query:
@@ -123,7 +123,7 @@ class KnowledgeBase(BaseModule):
         try:
             with open(file, "r") as f:
                 exist_search_results = json.load(f)
-        except:
+        except Exception:
             exist_search_results = {}
 
         if instruction in exist_search_results:

--- a/gui_agents/s2/agents/agent_s.py
+++ b/gui_agents/s2/agents/agent_s.py
@@ -348,7 +348,7 @@ class AgentS2(UIAgent):
             )
             try:
                 reflections = json.load(open(reflection_path))
-            except:
+            except Exception:
                 reflections = {}
 
             if self.search_query not in reflections:
@@ -387,7 +387,7 @@ class AgentS2(UIAgent):
                         self.local_kb_path, self.platform, "episodic_memory.json"
                     )
                     kb = json.load(open(subtask_path))
-                except:
+                except Exception:
                     kb = {}
                 if subtask_key not in kb.keys():
                     subtask_summarization = self.planner.summarize_episode(

--- a/gui_agents/s2/agents/grounding.py
+++ b/gui_agents/s2/agents/grounding.py
@@ -75,7 +75,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
     for k, v in new_cell_values.items():
         try:
             col, row = cell_ref_to_indices(k)
-        except:
+        except Exception:
             col = row = None
 
         if col is not None and row is not None:
@@ -127,7 +127,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
                 spreadsheet = spreadsheet[0][1]
 
             sheet = spreadsheet.Sheets.getByName(sheet_name)
-        except:
+        except Exception:
             raise ValueError(f"Could not find sheet {{sheet_name}} in {{app_name}}.")
 
         for (col, row), value in new_cell_values_idx.items():

--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -41,7 +41,7 @@ def get_char():
             import msvcrt
 
             return msvcrt.getch().decode("utf-8", errors="ignore")
-    except:
+    except Exception:
         return input()  # Fallback for non-terminal environments
 
 

--- a/gui_agents/s2/core/knowledge.py
+++ b/gui_agents/s2/core/knowledge.py
@@ -88,7 +88,7 @@ class KnowledgeBase(BaseModule):
         try:
             with open(query_path, "r") as f:
                 formulate_query = json.load(f)
-        except:
+        except Exception:
             formulate_query = {}
 
         if instruction in formulate_query:
@@ -129,7 +129,7 @@ class KnowledgeBase(BaseModule):
         try:
             with open(file, "r") as f:
                 exist_search_results = json.load(f)
-        except:
+        except Exception:
             exist_search_results = {}
 
         if instruction in exist_search_results:
@@ -271,7 +271,7 @@ class KnowledgeBase(BaseModule):
 
         try:
             kb = load_knowledge_base(self.episodic_memory_path)
-        except:
+        except Exception:
             kb = {}
 
         if subtask_key not in kb:
@@ -296,7 +296,7 @@ class KnowledgeBase(BaseModule):
 
         try:
             kb = load_knowledge_base(self.narrative_memory_path)
-        except:
+        except Exception:
             kb = {}
 
         if task_key not in kb:

--- a/gui_agents/s2_5/agents/grounding.py
+++ b/gui_agents/s2_5/agents/grounding.py
@@ -75,7 +75,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
     for k, v in new_cell_values.items():
         try:
             col, row = cell_ref_to_indices(k)
-        except:
+        except Exception:
             col = row = None
 
         if col is not None and row is not None:
@@ -127,7 +127,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
                 spreadsheet = spreadsheet[0][1]
 
             sheet = spreadsheet.Sheets.getByName(sheet_name)
-        except:
+        except Exception:
             raise ValueError(f"Could not find sheet {{sheet_name}} in {{app_name}}.")
 
         for (col, row), value in new_cell_values_idx.items():

--- a/gui_agents/s2_5/cli_app.py
+++ b/gui_agents/s2_5/cli_app.py
@@ -41,7 +41,7 @@ def get_char():
             import msvcrt
 
             return msvcrt.getch().decode("utf-8", errors="ignore")
-    except:
+    except Exception:
         return input()  # Fallback for non-terminal environments
 
 

--- a/gui_agents/s3/agents/grounding.py
+++ b/gui_agents/s3/agents/grounding.py
@@ -95,7 +95,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
     for k, v in new_cell_values.items():
         try:
             col, row = cell_ref_to_indices(k)
-        except:
+        except Exception:
             col = row = None
 
         if col is not None and row is not None:
@@ -147,7 +147,7 @@ def set_cell_values(new_cell_values: dict[str, str], app_name: str = "Untitled 1
                 spreadsheet = spreadsheet[0][1]
 
             sheet = spreadsheet.Sheets.getByName(sheet_name)
-        except:
+        except Exception:
             raise ValueError(f"Could not find sheet {{sheet_name}} in {{app_name}}.")
 
         for (col, row), value in new_cell_values_idx.items():

--- a/gui_agents/s3/bbon/comparative_judge.py
+++ b/gui_agents/s3/bbon/comparative_judge.py
@@ -21,7 +21,7 @@ def get_final_screenshot_file(task_dir: str) -> str:
     def extract_step_num(filename):
         try:
             return int(filename.split("_")[1].split(".")[0])
-        except:
+        except Exception:
             return 0
 
     screenshot_files.sort(key=extract_step_num)

--- a/gui_agents/s3/cli_app.py
+++ b/gui_agents/s3/cli_app.py
@@ -42,7 +42,7 @@ def get_char():
             import msvcrt
 
             return msvcrt.getch().decode("utf-8", errors="ignore")
-    except:
+    except Exception:
         return input()  # Fallback for non-terminal environments
 
 

--- a/osworld_setup/s1/run.py
+++ b/osworld_setup/s1/run.py
@@ -299,7 +299,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:

--- a/osworld_setup/s2/run.py
+++ b/osworld_setup/s2/run.py
@@ -363,7 +363,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:

--- a/osworld_setup/s2_5/run.py
+++ b/osworld_setup/s2_5/run.py
@@ -514,7 +514,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:

--- a/osworld_setup/s2_5/run_local.py
+++ b/osworld_setup/s2_5/run_local.py
@@ -364,7 +364,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:

--- a/osworld_setup/s3/bbon/generate_facts.py
+++ b/osworld_setup/s3/bbon/generate_facts.py
@@ -28,7 +28,7 @@ async def generate_single_fact_caption(
         try:
             data = json.loads(trajectory_lines[i])
             pyautogui_action = data.get("exec_code")
-        except:
+        except Exception:
             pass
 
     if pyautogui_action is None:
@@ -74,7 +74,7 @@ async def generate_fact_captions_parallel(
     def extract_step_num(filename):
         try:
             return int(filename.split("_")[1].split(".")[0])
-        except:
+        except Exception:
             return 0
 
     screenshot_files.sort(key=extract_step_num)
@@ -90,7 +90,7 @@ async def generate_fact_captions_parallel(
         try:
             with open(trajectory_file, "r") as f:
                 trajectory_lines = f.readlines()
-        except:
+        except Exception:
             pass
 
     # Use shared semaphore to limit concurrent judge calls

--- a/osworld_setup/s3/run.py
+++ b/osworld_setup/s3/run.py
@@ -520,7 +520,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:

--- a/osworld_setup/s3/run_local.py
+++ b/osworld_setup/s3/run_local.py
@@ -361,7 +361,7 @@ def get_result(action_space, use_model, observation_type, result_dir, total_file
                                     ).read()
                                 )
                             )
-                        except:
+                        except Exception:
                             all_result.append(0.0)
 
     if not all_result:


### PR DESCRIPTION
Replace 42 bare `except:` with `except Exception:` across 23 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors and preventing clean process termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling throughout the codebase by replacing generic error-catching with more specific exception types, enhancing code robustness and error handling clarity without changing user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->