### PR TITLE
feat: add LiteLLM as AI gateway engine

### DIFF
--- a/gui_agents/s2/core/engine.py
+++ b/gui_agents/s2/core/engine.py
@@ -451,6 +451,33 @@ class LMMEngineHuggingFace(LMMEngine):
         )
 
 
+class LMMEngineLiteLLM(LMMEngine):
+    def __init__(self, api_key=None, model=None, rate_limit=-1, **kwargs):
+        assert model is not None, "model must be provided"
+        self.model = model
+        self.api_key = api_key
+        self.request_interval = 0 if rate_limit == -1 else 60.0 / rate_limit
+
+    @backoff.on_exception(
+        backoff.expo, (APIConnectionError, APIError, RateLimitError), max_time=60
+    )
+    def generate(self, messages, temperature=0.0, max_new_tokens=None, **kwargs):
+        import litellm
+
+        params = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_new_tokens if max_new_tokens else 4096,
+            "temperature": temperature,
+            "drop_params": True,
+            **kwargs,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        response = litellm.completion(**params)
+        return response.choices[0].message.content
+
+
 class LMMEngineParasail(LMMEngine):
     def __init__(self, api_key=None, model=None, rate_limit=-1, **kwargs):
         assert model is not None, "Parasail model id must be provided"

--- a/gui_agents/s2/core/mllm.py
+++ b/gui_agents/s2/core/mllm.py
@@ -5,12 +5,13 @@ import numpy as np
 from gui_agents.s2.core.engine import (
     LMMEngineAnthropic,
     LMMEngineAzureOpenAI,
+    LMMEngineGemini,
     LMMEngineHuggingFace,
+    LMMEngineLiteLLM,
     LMMEngineOpenAI,
     LMMEngineOpenRouter,
     LMMEngineParasail,
     LMMEnginevLLM,
-    LMMEngineGemini,
 )
 
 
@@ -35,6 +36,8 @@ class LMMAgent:
                     self.engine = LMMEngineOpenRouter(**engine_params)
                 elif engine_type == "parasail":
                     self.engine = LMMEngineParasail(**engine_params)
+                elif engine_type == "litellm":
+                    self.engine = LMMEngineLiteLLM(**engine_params)
                 else:
                     raise ValueError("engine_type is not supported")
             else:
@@ -127,6 +130,7 @@ class LMMAgent:
                 LMMEngineAzureOpenAI,
                 LMMEngineHuggingFace,
                 LMMEngineGemini,
+                LMMEngineLiteLLM,
                 LMMEngineOpenRouter,
                 LMMEngineParasail,
             ),

--- a/gui_agents/s2_5/core/engine.py
+++ b/gui_agents/s2_5/core/engine.py
@@ -398,6 +398,33 @@ class LMMEngineHuggingFace(LMMEngine):
         )
 
 
+class LMMEngineLiteLLM(LMMEngine):
+    def __init__(self, api_key=None, model=None, rate_limit=-1, **kwargs):
+        assert model is not None, "model must be provided"
+        self.model = model
+        self.api_key = api_key
+        self.request_interval = 0 if rate_limit == -1 else 60.0 / rate_limit
+
+    @backoff.on_exception(
+        backoff.expo, (APIConnectionError, APIError, RateLimitError), max_time=60
+    )
+    def generate(self, messages, temperature=0.0, max_new_tokens=None, **kwargs):
+        import litellm
+
+        params = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_new_tokens if max_new_tokens else 4096,
+            "temperature": temperature,
+            "drop_params": True,
+            **kwargs,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        response = litellm.completion(**params)
+        return response.choices[0].message.content
+
+
 class LMMEngineParasail(LMMEngine):
     def __init__(
         self, base_url=None, api_key=None, model=None, rate_limit=-1, **kwargs

--- a/gui_agents/s2_5/core/mllm.py
+++ b/gui_agents/s2_5/core/mllm.py
@@ -5,12 +5,13 @@ import numpy as np
 from gui_agents.s2_5.core.engine import (
     LMMEngineAnthropic,
     LMMEngineAzureOpenAI,
+    LMMEngineGemini,
     LMMEngineHuggingFace,
+    LMMEngineLiteLLM,
     LMMEngineOpenAI,
     LMMEngineOpenRouter,
     LMMEngineParasail,
     LMMEnginevLLM,
-    LMMEngineGemini,
 )
 
 
@@ -35,6 +36,8 @@ class LMMAgent:
                     self.engine = LMMEngineOpenRouter(**engine_params)
                 elif engine_type == "parasail":
                     self.engine = LMMEngineParasail(**engine_params)
+                elif engine_type == "litellm":
+                    self.engine = LMMEngineLiteLLM(**engine_params)
                 else:
                     raise ValueError("engine_type is not supported")
             else:
@@ -127,6 +130,7 @@ class LMMAgent:
                 LMMEngineAzureOpenAI,
                 LMMEngineHuggingFace,
                 LMMEngineGemini,
+                LMMEngineLiteLLM,
                 LMMEngineOpenRouter,
                 LMMEngineParasail,
             ),

--- a/gui_agents/s3/core/engine.py
+++ b/gui_agents/s3/core/engine.py
@@ -402,6 +402,37 @@ class LMMEngineHuggingFace(LMMEngine):
         )
 
 
+class LMMEngineLiteLLM(LMMEngine):
+    def __init__(
+        self, api_key=None, model=None, rate_limit=-1, temperature=None, **kwargs
+    ):
+        assert model is not None, "model must be provided"
+        self.model = model
+        self.api_key = api_key
+        self.request_interval = 0 if rate_limit == -1 else 60.0 / rate_limit
+        self.temperature = temperature
+
+    @backoff.on_exception(
+        backoff.expo, (APIConnectionError, APIError, RateLimitError), max_time=60
+    )
+    def generate(self, messages, temperature=0.0, max_new_tokens=None, **kwargs):
+        import litellm
+
+        temp = self.temperature if self.temperature is not None else temperature
+        params = {
+            "model": self.model,
+            "messages": messages,
+            "max_tokens": max_new_tokens if max_new_tokens else 4096,
+            "temperature": temp,
+            "drop_params": True,
+            **kwargs,
+        }
+        if self.api_key:
+            params["api_key"] = self.api_key
+        response = litellm.completion(**params)
+        return response.choices[0].message.content
+
+
 class LMMEngineParasail(LMMEngine):
     def __init__(
         self, base_url=None, api_key=None, model=None, rate_limit=-1, **kwargs

--- a/gui_agents/s3/core/mllm.py
+++ b/gui_agents/s3/core/mllm.py
@@ -5,12 +5,13 @@ import numpy as np
 from gui_agents.s3.core.engine import (
     LMMEngineAnthropic,
     LMMEngineAzureOpenAI,
+    LMMEngineGemini,
     LMMEngineHuggingFace,
+    LMMEngineLiteLLM,
     LMMEngineOpenAI,
     LMMEngineOpenRouter,
     LMMEngineParasail,
     LMMEnginevLLM,
-    LMMEngineGemini,
 )
 
 
@@ -35,6 +36,8 @@ class LMMAgent:
                     self.engine = LMMEngineOpenRouter(**engine_params)
                 elif engine_type == "parasail":
                     self.engine = LMMEngineParasail(**engine_params)
+                elif engine_type == "litellm":
+                    self.engine = LMMEngineLiteLLM(**engine_params)
                 else:
                     raise ValueError(f"engine_type '{engine_type}' is not supported")
             else:
@@ -127,6 +130,7 @@ class LMMAgent:
                 LMMEngineAzureOpenAI,
                 LMMEngineHuggingFace,
                 LMMEngineGemini,
+                LMMEngineLiteLLM,
                 LMMEngineOpenRouter,
                 LMMEngineParasail,
             ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ toml
 black
 pytesseract
 google-genai
+litellm>=1.60.0,<2.0.0
 
 # Platform-specific dependencies
 pyobjc; platform_system == "Darwin"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "toml",
         "pytesseract",
         "google-genai",
+        "litellm>=1.60.0,<2.0.0",
         'pywinauto; platform_system == "Windows"',  # Only for Windows
         'pywin32; platform_system == "Windows"',  # Only for Windows
     ],

--- a/tests/test_litellm_engine.py
+++ b/tests/test_litellm_engine.py
@@ -1,0 +1,235 @@
+"""Tests for the LiteLLM engine across all Agent-S versions (s2, s2_5, s3)."""
+
+import types as builtin_types
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake response helpers
+# ---------------------------------------------------------------------------
+
+
+class _Msg:
+    def __init__(self, content="hello"):
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content="hello"):
+        self.message = _Msg(content=content)
+
+
+class _Response:
+    def __init__(self, content="hello"):
+        self.choices = [_Choice(content=content)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers to inject a fake litellm module
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_litellm(response_content="hello"):
+    import sys
+
+    fake = builtin_types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(return_value=_Response(response_content))
+    sys.modules["litellm"] = fake
+    return fake
+
+
+def _uninstall_fake_litellm():
+    import sys
+
+    sys.modules.pop("litellm", None)
+
+
+# ---------------------------------------------------------------------------
+# s3 engine tests
+# ---------------------------------------------------------------------------
+
+
+class TestS3EngineLiteLLM:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("s3 response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_generate_returns_content(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key="test-key", model="openai/gpt-4o")
+        result = engine.generate(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.5,
+            max_new_tokens=100,
+        )
+        assert result == "s3 response"
+
+    def test_generate_passes_drop_params(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key="test-key", model="anthropic/claude-3-haiku")
+        engine.generate(
+            messages=[{"role": "user", "content": "test"}],
+        )
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_generate_passes_model(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(model="bedrock/anthropic.claude-v2")
+        engine.generate(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["model"] == "bedrock/anthropic.claude-v2"
+
+    def test_generate_forwards_api_key(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key="sk-test", model="openai/gpt-4o")
+        engine.generate(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test"
+
+    def test_generate_omits_api_key_when_none(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key=None, model="openai/gpt-4o")
+        engine.generate(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert "api_key" not in call_kwargs
+
+    def test_instance_temperature_overrides_param(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(model="openai/gpt-4o", temperature=0.9)
+        engine.generate(
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=0.1,
+        )
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["temperature"] == 0.9
+
+    def test_default_max_tokens(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(model="openai/gpt-4o")
+        engine.generate(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["max_tokens"] == 4096
+
+
+# ---------------------------------------------------------------------------
+# s2 engine tests
+# ---------------------------------------------------------------------------
+
+
+class TestS2EngineLiteLLM:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("s2 response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_generate_returns_content(self):
+        from gui_agents.s2.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key="test-key", model="openai/gpt-4o")
+        result = engine.generate(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result == "s2 response"
+
+    def test_drop_params_default(self):
+        from gui_agents.s2.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(model="openai/gpt-4o")
+        engine.generate(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+
+# ---------------------------------------------------------------------------
+# s2_5 engine tests
+# ---------------------------------------------------------------------------
+
+
+class TestS25EngineLiteLLM:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("s2_5 response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_generate_returns_content(self):
+        from gui_agents.s2_5.core.engine import LMMEngineLiteLLM
+
+        engine = LMMEngineLiteLLM(api_key="test-key", model="openai/gpt-4o")
+        result = engine.generate(
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result == "s2_5 response"
+
+
+# ---------------------------------------------------------------------------
+# LMMAgent registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestLMMAgentRegistration:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("agent response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_s3_agent_creates_litellm_engine(self):
+        from gui_agents.s3.core.engine import LMMEngineLiteLLM
+        from gui_agents.s3.core.mllm import LMMAgent
+
+        agent = LMMAgent(
+            engine_params={"engine_type": "litellm", "model": "openai/gpt-4o"},
+        )
+        assert isinstance(agent.engine, LMMEngineLiteLLM)
+
+    def test_s3_agent_get_response(self):
+        from gui_agents.s3.core.mllm import LMMAgent
+
+        agent = LMMAgent(
+            engine_params={
+                "engine_type": "litellm",
+                "model": "openai/gpt-4o",
+                "api_key": "test",
+            },
+            system_prompt="You are helpful.",
+        )
+        resp = agent.get_response(user_message="hi")
+        assert resp == "agent response"
+
+    def test_s2_agent_creates_litellm_engine(self):
+        from gui_agents.s2.core.engine import LMMEngineLiteLLM
+        from gui_agents.s2.core.mllm import LMMAgent
+
+        agent = LMMAgent(
+            engine_params={"engine_type": "litellm", "model": "openai/gpt-4o"},
+        )
+        assert isinstance(agent.engine, LMMEngineLiteLLM)
+
+    def test_s2_5_agent_creates_litellm_engine(self):
+        from gui_agents.s2_5.core.engine import LMMEngineLiteLLM
+        from gui_agents.s2_5.core.mllm import LMMAgent
+
+        agent = LMMAgent(
+            engine_params={"engine_type": "litellm", "model": "openai/gpt-4o"},
+        )
+        assert isinstance(agent.engine, LMMEngineLiteLLM)
+
+    def test_unsupported_engine_raises(self):
+        from gui_agents.s3.core.mllm import LMMAgent
+
+        with pytest.raises(ValueError, match="not supported"):
+            LMMAgent(engine_params={"engine_type": "nonexistent", "model": "x"})


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Adds `LMMEngineLiteLLM` as a new engine type across all Agent-S versions (s2, s2_5, s3)                                                                                                                          
  - Gives users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Cohere, Ollama, etc.) through a single unified interface
  - Users switch providers by changing the model string, no code changes needed                                                                                                                                      
  - Follows the exact same `LMMEngine` pattern used by the existing 8 engines
                                                                                                                                                                                                                     
  ---             
                                                                                                                                                                                                                     
  - **What kind of change does this PR introduce?** Feature, adds LiteLLM as a new LLM engine

  - **Why was this change needed?** Agent-S currently has 8 individual LLM engines (OpenAI, Anthropic, Gemini, Azure, OpenRouter, vLLM, HuggingFace, Parasail), each maintained separately. LiteLLM provides a       
  unified interface to 100+ LLM providers through a single `completion()` call. Users switch providers by changing the model string, no code changes needed. 
  - **Other information**: See sections below.                                                                                                                                                                                                                                                                                                                   
                  
  ---   

  ## What Changed

  | File | Change |
  |---|---|
  | `gui_agents/s2/core/engine.py` | Added `LMMEngineLiteLLM` class |
  | `gui_agents/s2/core/mllm.py` | Registered `litellm` engine type + `isinstance` check |                                                                                                                           
  | `gui_agents/s2_5/core/engine.py` | Added `LMMEngineLiteLLM` class |
  | `gui_agents/s2_5/core/mllm.py` | Registered `litellm` engine type + `isinstance` check |                                                                                                                         
  | `gui_agents/s3/core/engine.py` | Added `LMMEngineLiteLLM` class |
  | `gui_agents/s3/core/mllm.py` | Registered `litellm` engine type + `isinstance` check |                                                                                                                           
  | `setup.py` | Added `litellm>=1.60.0,<2.0.0` |
  | `requirements.txt` | Added `litellm>=1.60.0,<2.0.0` |                                                                                                                                                            
  | `tests/test_litellm_engine.py` | 15 unit tests across all versions |
                                                                                                                                                                                                                     
  ---             

  ## Usage                                                                                                                                                                                                           
   
  ### Quick Start                                                                                                                                                                                                    
                  
  ```python
  from gui_agents.s3.core.mllm import LMMAgent

  agent = LMMAgent(
      engine_params={
          "engine_type": "litellm",
          "model": "anthropic/claude-3-haiku",  # any LiteLLM model string
      },                                                                                                                                                                                                             
      system_prompt="You are a helpful assistant.",
  )                                                                                                                                                                                                                  
                  
  response = agent.get_response(user_message="What is 2+2?")
  print(response)

  Switching Providers: Just Change the Model String                                                                                                                                                                  
   
  # OpenAI                                                                                                                                                                                                           
  engine_params = {"engine_type": "litellm", "model": "openai/gpt-4o"}

  # Anthropic
  engine_params = {"engine_type": "litellm", "model": "anthropic/claude-3-haiku"}
                                                                                                                                                                                                                     
  # AWS Bedrock
  engine_params = {"engine_type": "litellm", "model": "bedrock/anthropic.claude-v2"}                                                                                                                                 
                  
  # Google Vertex AI
  engine_params = {"engine_type": "litellm", "model": "vertex_ai/gemini-pro"}
                                                                                                                                                                                                                     
  # Groq
  engine_params = {"engine_type": "litellm", "model": "groq/llama3-70b-8192"}                                                                                                                                        
                  
  # Local Ollama
  engine_params = {"engine_type": "litellm", "model": "ollama/llama3"}
```                                                                                                                                                                                                                     
  Provider API keys are read from standard environment variables automatically (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.), or pass api_key in engine_params.                                                          
                                                                                                                                                                                                                     
  Any of the https://docs.litellm.ai/docs/providers works.                                                                                                                                                           
                  
  Direct Engine Usage (Without LMMAgent)

  ```python
  from gui_agents.s3.core.engine import LMMEngineLiteLLM
                                                                                                                                                                                                                     
  engine = LMMEngineLiteLLM(model="openai/gpt-4o", api_key="sk-...")
                                                                                                                                                                                                                     
  response = engine.generate(
      messages=[
          {"role": "system", "content": [{"type": "text", "text": "You are helpful."}]},
          {"role": "user", "content": [{"type": "text", "text": "Hello!"}]},                                                                                                                                         
      ],
      temperature=0.7,                                                                                                                                                                                               
      max_new_tokens=100,
  )                                                                                                                                                                                                                  
  print(response)
```                                                                                                                                                                                                                     
  ---             
  Testing

  Unit Tests (15/15 Passing)
```
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_generate_returns_content PASSED
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_generate_passes_drop_params PASSED
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_generate_passes_model PASSED                                                                                                                               
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_generate_forwards_api_key PASSED                                                                                                                           
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_generate_omits_api_key_when_none PASSED                                                                                                                    
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_instance_temperature_overrides_param PASSED                                                                                                                
  tests/test_litellm_engine.py::TestS3EngineLiteLLM::test_default_max_tokens PASSED
  tests/test_litellm_engine.py::TestS2EngineLiteLLM::test_generate_returns_content PASSED                                                                                                                            
  tests/test_litellm_engine.py::TestS2EngineLiteLLM::test_drop_params_default PASSED
  tests/test_litellm_engine.py::TestS25EngineLiteLLM::test_generate_returns_content PASSED                                                                                                                           
  tests/test_litellm_engine.py::TestLMMAgentRegistration::test_s3_agent_creates_litellm_engine PASSED
  tests/test_litellm_engine.py::TestLMMAgentRegistration::test_s3_agent_get_response PASSED                                                                                                                          
  tests/test_litellm_engine.py::TestLMMAgentRegistration::test_s2_agent_creates_litellm_engine PASSED
  tests/test_litellm_engine.py::TestLMMAgentRegistration::test_s2_5_agent_creates_litellm_engine PASSED                                                                                                              
  tests/test_litellm_engine.py::TestLMMAgentRegistration::test_unsupported_engine_raises PASSED                                                                                                                      
  ============================== 15 passed in 0.99s ==============================                                                                                                                                   
  ```                                                                                                                                                                                                                   
  Live E2E (Azure AI Foundry, Claude Sonnet via LiteLLM)                                                                                                                                                             
   
  Model: azure_ai/claude-sonnet-4-6                                                                                                                                                                                  
                  
  LMMEngineLiteLLM.generate() -> "4"
  LMMAgent.get_response()     -> "1, 2, 3"
                                                                                                                                                                                                                     
  ---
  Risk / Compatibility                                                                                                                                                                                               
                  
  - Additive only, no existing engine code changed
  - drop_params=True set by default so provider-unsupported kwargs are silently dropped
  - LiteLLM lazily imported inside generate(), users who don't use this engine are unaffected
  - Added to all 3 versions (s2, s2_5, s3) for consistency   