### PR TITLE
fix: avoid shell interpolation in permission dialogs

### DIFF
--- a/gui_agents/s1/cli_app.py
+++ b/gui_agents/s1/cli_app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import signal
+import subprocess
 import sys
 import time
 
@@ -138,16 +139,38 @@ platform_os = platform.system()
 
 def show_permission_dialog(code: str, action_description: str):
     """Show a platform-specific permission dialog and return True if approved."""
+    prompt_text = (
+        "Do you want to execute this action?\n\n"
+        f"{code}"
+    )
+    if action_description:
+        prompt_text += f" which will try to {action_description}"
+
     if platform.system() == "Darwin":
-        result = os.system(
-            f'osascript -e \'display dialog "Do you want to execute this action?\n\n{code} which will try to {action_description}" with title "Action Permission" buttons {{"Cancel", "OK"}} default button "OK" cancel button "Cancel"\''
+        script = (
+            'display dialog argv item 1 with title "Action Permission" '
+            'buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"'
         )
-        return result == 0
+        result = subprocess.run(
+            ["osascript", "-e", script, prompt_text],
+            check=False,
+        )
+        return result.returncode == 0
     elif platform.system() == "Linux":
-        result = os.system(
-            f'zenity --question --title="Action Permission" --text="Do you want to execute this action?\n\n{code}" --width=400 --height=200'
+        result = subprocess.run(
+            [
+                "zenity",
+                "--question",
+                "--title",
+                "Action Permission",
+                "--text",
+                prompt_text,
+                "--width=400",
+                "--height=200",
+            ],
+            check=False,
         )
-        return result == 0
+        return result.returncode == 0
     return False
 
 

--- a/gui_agents/s2/cli_app.py
+++ b/gui_agents/s2/cli_app.py
@@ -6,6 +6,7 @@ import os
 import platform
 import pyautogui
 import signal
+import subprocess
 import sys
 import time
 
@@ -131,16 +132,38 @@ platform_os = platform.system()
 
 def show_permission_dialog(code: str, action_description: str):
     """Show a platform-specific permission dialog and return True if approved."""
+    prompt_text = (
+        "Do you want to execute this action?\n\n"
+        f"{code}"
+    )
+    if action_description:
+        prompt_text += f" which will try to {action_description}"
+
     if platform.system() == "Darwin":
-        result = os.system(
-            f'osascript -e \'display dialog "Do you want to execute this action?\n\n{code} which will try to {action_description}" with title "Action Permission" buttons {{"Cancel", "OK"}} default button "OK" cancel button "Cancel"\''
+        script = (
+            'display dialog argv item 1 with title "Action Permission" '
+            'buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"'
         )
-        return result == 0
+        result = subprocess.run(
+            ["osascript", "-e", script, prompt_text],
+            check=False,
+        )
+        return result.returncode == 0
     elif platform.system() == "Linux":
-        result = os.system(
-            f'zenity --question --title="Action Permission" --text="Do you want to execute this action?\n\n{code}" --width=400 --height=200'
+        result = subprocess.run(
+            [
+                "zenity",
+                "--question",
+                "--title",
+                "Action Permission",
+                "--text",
+                prompt_text,
+                "--width=400",
+                "--height=200",
+            ],
+            check=False,
         )
-        return result == 0
+        return result.returncode == 0
     return False
 
 

--- a/gui_agents/s2_5/cli_app.py
+++ b/gui_agents/s2_5/cli_app.py
@@ -6,6 +6,7 @@ import os
 import platform
 import pyautogui
 import signal
+import subprocess
 import sys
 import time
 
@@ -131,16 +132,38 @@ platform_os = platform.system()
 
 def show_permission_dialog(code: str, action_description: str):
     """Show a platform-specific permission dialog and return True if approved."""
+    prompt_text = (
+        "Do you want to execute this action?\n\n"
+        f"{code}"
+    )
+    if action_description:
+        prompt_text += f" which will try to {action_description}"
+
     if platform.system() == "Darwin":
-        result = os.system(
-            f'osascript -e \'display dialog "Do you want to execute this action?\n\n{code} which will try to {action_description}" with title "Action Permission" buttons {{"Cancel", "OK"}} default button "OK" cancel button "Cancel"\''
+        script = (
+            'display dialog argv item 1 with title "Action Permission" '
+            'buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"'
         )
-        return result == 0
+        result = subprocess.run(
+            ["osascript", "-e", script, prompt_text],
+            check=False,
+        )
+        return result.returncode == 0
     elif platform.system() == "Linux":
-        result = os.system(
-            f'zenity --question --title="Action Permission" --text="Do you want to execute this action?\n\n{code}" --width=400 --height=200'
+        result = subprocess.run(
+            [
+                "zenity",
+                "--question",
+                "--title",
+                "Action Permission",
+                "--text",
+                prompt_text,
+                "--width=400",
+                "--height=200",
+            ],
+            check=False,
         )
-        return result == 0
+        return result.returncode == 0
     return False
 
 

--- a/gui_agents/s3/cli_app.py
+++ b/gui_agents/s3/cli_app.py
@@ -6,6 +6,7 @@ import os
 import platform
 import pyautogui
 import signal
+import subprocess
 import sys
 import time
 
@@ -132,16 +133,38 @@ platform_os = platform.system()
 
 def show_permission_dialog(code: str, action_description: str):
     """Show a platform-specific permission dialog and return True if approved."""
+    prompt_text = (
+        "Do you want to execute this action?\n\n"
+        f"{code}"
+    )
+    if action_description:
+        prompt_text += f" which will try to {action_description}"
+
     if platform.system() == "Darwin":
-        result = os.system(
-            f'osascript -e \'display dialog "Do you want to execute this action?\n\n{code} which will try to {action_description}" with title "Action Permission" buttons {{"Cancel", "OK"}} default button "OK" cancel button "Cancel"\''
+        script = (
+            'display dialog argv item 1 with title "Action Permission" '
+            'buttons {"Cancel", "OK"} default button "OK" cancel button "Cancel"'
         )
-        return result == 0
+        result = subprocess.run(
+            ["osascript", "-e", script, prompt_text],
+            check=False,
+        )
+        return result.returncode == 0
     elif platform.system() == "Linux":
-        result = os.system(
-            f'zenity --question --title="Action Permission" --text="Do you want to execute this action?\n\n{code}" --width=400 --height=200'
+        result = subprocess.run(
+            [
+                "zenity",
+                "--question",
+                "--title",
+                "Action Permission",
+                "--text",
+                prompt_text,
+                "--width=400",
+                "--height=200",
+            ],
+            check=False,
         )
-        return result == 0
+        return result.returncode == 0
     return False
 
 

--- a/tests/test_permission_dialogs.py
+++ b/tests/test_permission_dialogs.py
@@ -1,0 +1,72 @@
+import ast
+import subprocess
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+CLI_APPS = (
+    "gui_agents/s1/cli_app.py",
+    "gui_agents/s2/cli_app.py",
+    "gui_agents/s2_5/cli_app.py",
+    "gui_agents/s3/cli_app.py",
+)
+
+
+def load_permission_dialog(path: str):
+    """Load only the dialog helper so CLI module side effects are not executed."""
+    source_path = Path(path)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=path)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "show_permission_dialog"
+    )
+    module = SimpleNamespace(
+        platform=SimpleNamespace(system=Mock()),
+        subprocess=SimpleNamespace(run=Mock()),
+    )
+    namespace = {"platform": module.platform, "subprocess": module.subprocess}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), path, "exec"), namespace)
+    return namespace["show_permission_dialog"], module
+
+
+class PermissionDialogTests(unittest.TestCase):
+    def test_macos_passes_model_text_as_osascript_argv(self):
+        model_text = '"; do shell script "touch /tmp/pwned"; "'
+
+        for path in CLI_APPS:
+            with self.subTest(path=path):
+                show_permission_dialog, module = load_permission_dialog(path)
+                module.platform.system.return_value = "Darwin"
+                module.subprocess.run.return_value = subprocess.CompletedProcess([], 0)
+
+                self.assertTrue(show_permission_dialog(model_text, "open settings"))
+
+                argv = module.subprocess.run.call_args.args[0]
+                self.assertEqual(argv[:2], ["osascript", "-e"])
+                self.assertIn("argv item 1", argv[2])
+                self.assertNotIn(model_text, argv[2])
+                self.assertIn(model_text, argv[3])
+                self.assertEqual(module.subprocess.run.call_args.kwargs, {"check": False})
+
+    def test_linux_passes_model_text_as_zenity_argv(self):
+        model_text = '$(touch /tmp/pwned); `id`; "quoted"'
+
+        for path in CLI_APPS:
+            with self.subTest(path=path):
+                show_permission_dialog, module = load_permission_dialog(path)
+                module.platform.system.return_value = "Linux"
+                module.subprocess.run.return_value = subprocess.CompletedProcess([], 1)
+
+                self.assertFalse(show_permission_dialog(model_text, "open settings"))
+
+                argv = module.subprocess.run.call_args.args[0]
+                self.assertEqual(argv[0], "zenity")
+                self.assertEqual(argv[argv.index("--text") + 1].count(model_text), 1)
+                self.assertEqual(module.subprocess.run.call_args.kwargs, {"check": False})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace shell-based `os.system(...)` permission prompts with `subprocess.run(...)`
- pass dialog content as argv data instead of interpolating model-generated text into shell commands
- apply the fix across the S1, S2, S2.5, and S3 CLI entrypoints

## Problem
The permission dialog code interpolated model-generated `code` and `action_description` into shell command strings for `osascript` and `zenity`. That allowed shell metacharacters or broken quoting in the generated action text to execute commands before user approval.

## Fix
- macOS: call `osascript` with a fixed script and pass the prompt text as an argument
- Linux: call `zenity` with argv items instead of a shell string
- preserve existing behavior while treating the displayed action text strictly as data

## Verification
- `python3 -m py_compile gui_agents/s1/cli_app.py gui_agents/s2/cli_app.py gui_agents/s2_5/cli_app.py gui_agents/s3/cli_app.py`

Closes #196
