### PR TITLE
Fix: WindowsACI.hotkey() splitting key names into characters

### DIFF
--- a/gui_agents/s1/aci/WindowsOSACI.py
+++ b/gui_agents/s1/aci/WindowsOSACI.py
@@ -405,6 +405,9 @@ class WindowsACI(ACI):
         Args:
             keys:List[str] the keys to press in combination in a list format (e.g. ['shift', 'c'])
         """
+        # Ensure keys is a list - if a string is passed, wrap it
+        if isinstance(keys, str):
+            keys = [keys]
         keys = [_normalize_key(k) for k in keys]
         keys = [f"'{key}'" for key in keys]
         command = f"import pyautogui; pyautogui.hotkey({', '.join(keys)}, interval=0.5)"

--- a/tests/test_windows_aci.py
+++ b/tests/test_windows_aci.py
@@ -1,0 +1,57 @@
+import unittest
+from gui_agents.s1.aci.WindowsOSACI import WindowsACI
+
+
+class TestWindowsACIHotkey(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures"""
+        self.aci = WindowsACI(top_app_only=True, ocr=False)
+
+    def test_hotkey_with_string_single_key(self):
+        """Test that passing a string like 'enter' works correctly"""
+        result = self.aci.hotkey('enter')
+        expected = "import pyautogui; pyautogui.hotkey('enter', interval=0.5)"
+        self.assertEqual(result, expected)
+
+    def test_hotkey_with_list_single_key(self):
+        """Test that passing a list with a single key works correctly"""
+        result = self.aci.hotkey(['enter'])
+        expected = "import pyautogui; pyautogui.hotkey('enter', interval=0.5)"
+        self.assertEqual(result, expected)
+
+    def test_hotkey_with_list_multiple_keys(self):
+        """Test that passing a list with multiple keys works correctly"""
+        result = self.aci.hotkey(['alt', 'tab'])
+        expected = "import pyautogui; pyautogui.hotkey('alt', 'tab', interval=0.5)"
+        self.assertEqual(result, expected)
+
+    def test_hotkey_with_control_normalization(self):
+        """Test that 'control' is normalized to 'ctrl'"""
+        result = self.aci.hotkey(['control', 'c'])
+        expected = "import pyautogui; pyautogui.hotkey('ctrl', 'c', interval=0.5)"
+        self.assertEqual(result, expected)
+
+    def test_hotkey_with_string_special_keys(self):
+        """Test various special key strings"""
+        test_cases = [
+            ('escape', "import pyautogui; pyautogui.hotkey('escape', interval=0.5)"),
+            ('space', "import pyautogui; pyautogui.hotkey('space', interval=0.5)"),
+            ('backspace', "import pyautogui; pyautogui.hotkey('backspace', interval=0.5)"),
+            ('delete', "import pyautogui; pyautogui.hotkey('delete', interval=0.5)"),
+        ]
+        for key, expected in test_cases:
+            with self.subTest(key=key):
+                result = self.aci.hotkey(key)
+                self.assertEqual(result, expected)
+
+    def test_hotkey_does_not_split_string(self):
+        """Regression test: ensure 'enter' doesn't become 'e', 'n', 't', 'e', 'r'"""
+        result = self.aci.hotkey('enter')
+        # This should NOT contain individual characters
+        self.assertNotIn("'e', 'n', 't', 'e', 'r'", result)
+        # This SHOULD contain the full key name
+        self.assertIn("'enter'", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #195 - WindowsACI.hotkey() was splitting single key names like 'enter' into individual characters ('e', 'n', 't', 'e', 'r') when passed as a string instead of a list.

## Problem

When calling `aci.hotkey('enter')` with a string, Python's iteration over the string caused each character to be treated as a separate key, resulting in:
```python
"import pyautogui; pyautogui.hotkey('e', 'n', 't', 'e', 'r', interval=0.5)"
```

instead of the expected:
```python
"import pyautogui; pyautogui.hotkey('enter', interval=0.5)"
```

## Solution

Added a type check in the `hotkey()` method to ensure the `keys` parameter is always a list:
- If a string is passed, it's wrapped in a list before processing
- Maintains backward compatibility with list inputs
- Preserves existing functionality for multi-key combinations

## Changes

- **Modified**: `gui_agents/s1/aci/WindowsOSACI.py` - Added type check in `hotkey()` method
- **Added**: `tests/test_windows_aci.py` - Comprehensive unit tests including:
  - Single key as string (`'enter'`)
  - Single key as list (`['enter']`)
  - Multiple keys (`['alt', 'tab']`)
  - Control key normalization
  - Regression test to ensure strings aren't split into characters

## Testing

Created unit tests that verify:
- ✅ String inputs like `'enter'` work correctly
- ✅ List inputs like `['enter']` continue to work
- ✅ Multi-key combinations like `['alt', 'tab']` work
- ✅ Control key normalization still functions
- ✅ No regression: strings don't get split into characters

All tests will run in CI.


Made with [Cursor](https://cursor.com)