### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,4 +363,4 @@ If you find this codebase useful, please cite:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=simular-ai/Agent-S&type=Date)](https://star-history.com/#simular-ai/Agent-S&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=simular-ai/Agent-S&type=Date)](https://star-history.dera.page/#simular-ai/Agent-S&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying GitHub stargazer data source is restricted. This PR switches the chart to an alternative data source so the chart renders correctly again, while keeping the existing badge untouched.