### PR TITLE
fix: avoid index-shift bug when trimming images in flush_messages

### DIFF
--- a/gui_agents/s2_5/agents/worker.py
+++ b/gui_agents/s2_5/agents/worker.py
@@ -82,7 +82,7 @@ class Worker(BaseModule):
                 # keep latest k images
                 img_count = 0
                 for i in range(len(agent.messages) - 1, -1, -1):
-                    for j in range(len(agent.messages[i]["content"])):
+                    for j in range(len(agent.messages[i]["content"]) - 1, -1, -1):
                         if "image" in agent.messages[i]["content"][j].get("type", ""):
                             img_count += 1
                             if img_count > max_images:

--- a/gui_agents/s3/agents/worker.py
+++ b/gui_agents/s3/agents/worker.py
@@ -106,7 +106,7 @@ class Worker(BaseModule):
                 # keep latest k images
                 img_count = 0
                 for i in range(len(agent.messages) - 1, -1, -1):
-                    for j in range(len(agent.messages[i]["content"])):
+                    for j in range(len(agent.messages[i]["content"]) - 1, -1, -1):
                         if "image" in agent.messages[i]["content"][j].get("type", ""):
                             img_count += 1
                             if img_count > max_images:

--- a/tests/test_flush_messages.py
+++ b/tests/test_flush_messages.py
@@ -1,0 +1,71 @@
+import unittest
+from types import SimpleNamespace
+
+from gui_agents.s2_5.agents.worker import Worker as WorkerS2_5
+from gui_agents.s3.agents.worker import Worker as WorkerS3
+
+
+def _count_images(messages):
+    return sum(
+        1 for m in messages for c in m["content"] if "image" in c.get("type", "")
+    )
+
+
+class FlushMessagesMixin:
+    worker_cls = None
+
+    def _make_worker(self, messages, max_images=2, engine_type="openai"):
+        # Build a Worker without running __init__ (avoids network / model setup).
+        w = self.worker_cls.__new__(self.worker_cls)
+        w.engine_params = {"engine_type": engine_type}
+        w.max_trajectory_length = max_images
+        w.generator_agent = SimpleNamespace(messages=messages)
+        w.reflection_agent = SimpleNamespace(messages=[])
+        return w
+
+    def test_single_message_with_multiple_images(self):
+        messages = [
+            {"content": [{"type": "text"}] + [{"type": "image_url"}] * 4},
+        ]
+        self._make_worker(messages, max_images=2).flush_messages()
+        self.assertEqual(_count_images(messages), 2)
+
+    def test_images_across_messages(self):
+        messages = [
+            {"content": [{"type": "text"}, {"type": "image_url"}]} for _ in range(5)
+        ]
+        self._make_worker(messages, max_images=2).flush_messages()
+        self.assertEqual(_count_images(messages), 2)
+
+    def test_keeps_newest_images(self):
+        messages = [
+            {
+                "content": [
+                    {"type": "text"},
+                    {"type": "image_url", "tag": "old"},
+                    {"type": "image_url", "tag": "new"},
+                ]
+            }
+        ]
+        self._make_worker(messages, max_images=1).flush_messages()
+        kept = [c for c in messages[0]["content"] if "image" in c.get("type", "")]
+        self.assertEqual([c["tag"] for c in kept], ["new"])
+
+    def test_text_entries_are_preserved(self):
+        messages = [
+            {"content": [{"type": "text"}] + [{"type": "image_url"}] * 3},
+        ]
+        self._make_worker(messages, max_images=0).flush_messages()
+        self.assertEqual(messages[0]["content"], [{"type": "text"}])
+
+
+class TestFlushMessagesS3(FlushMessagesMixin, unittest.TestCase):
+    worker_cls = WorkerS3
+
+
+class TestFlushMessagesS2_5(FlushMessagesMixin, unittest.TestCase):
+    worker_cls = WorkerS2_5
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`Worker.flush_messages()` trims old images from the LLM message history to keep at most `max_trajectory_length` images in the prompt. For long-context providers (`anthropic`, `openai`, `gemini`) it walks each message's `content` list and deletes image entries once the running count exceeds `max_images`:

```python
for i in range(len(agent.messages) - 1, -1, -1):
    for j in range(len(agent.messages[i]["content"])):
        if "image" in agent.messages[i]["content"][j].get("type", ""):
            img_count += 1
            if img_count > max_images:
                del agent.messages[i]["content"][j]   # shifts every later index
```

The outer loop iterates in reverse, but the **inner** loop does not. `del` at index `j` shifts every subsequent element down by one while the loop keeps walking indices computed from the original length. For a message whose `content` holds more than one image, that means:

1. **images get skipped**, so more than `max_trajectory_length` images can survive into the prompt, and
2. it can raise **`IndexError: list index out of range`**.

There is also a smaller correctness problem independent of the deletion bug: because the inner loop counts front-to-back, the images kept within a single message are the **oldest** ones, not the newest — the opposite of the intended "keep the latest k images" policy.

### Scope — this is a latent bug

I want to be upfront that I found this by reading the code, not from a failing run.

As of this commit the bug is **not reachable** through the current call paths: every `add_message` call feeding the two agents `flush_messages` operates on (`worker.py:153`, `worker.py:160`, `worker.py:305`) passes a single `obs["screenshot"]`, so each message holds exactly one image and no deletion ever shifts an unvisited index.

It is reachable the moment any caller passes multiple images for one message, which `LMMAgent.add_message` / `add_message_to_role` explicitly support — they accept a **list** and append one `content` entry per image (`gui_agents/s3/core/mllm.py:211-225`). So this is hardening a landmine rather than fixing a live crash, plus the newest-vs-oldest fix above.

To be clear about what this does **not** do: it does not fix #168. That report is a configuration mismatch — `max_trajectory_length` defaults to 8 (`worker.py:30`, `agent_s.py:56`) while the provider there caps at 3 images — and `flush_messages` behaves as designed in that scenario. Happy to look at that separately if it'd be useful.

## Fix

Iterate the inner loop in reverse as well. Deleting index `j` then only affects indices `> j`, which have already been visited, so nothing is skipped and no out-of-range access occurs. Walking content back-to-front also counts the most-recently-appended images first, matching the intended policy.

One line in each of the two affected files:

- `gui_agents/s3/agents/worker.py`
- `gui_agents/s2_5/agents/worker.py`

## Tests

Adds `tests/test_flush_messages.py`, exercising the real `Worker.flush_messages` on both `s3` and `s2_5` (constructed via `__new__` so no network or model setup is needed). Coverage:

- multiple images within a **single** message
- images spread **across** messages
- the **newest** images are the ones kept
- non-image `content` entries are preserved

Reproduction, one message with 4 images and `max_images=2`:

```
before:  CRASHED: IndexError: list index out of range
after:   kept 2 images (expected 2)
```

6 of the 8 new cases fail on `main`; all 8 pass with the fix.

`black --check gui_agents` passes.

If you'd rather not carry tests for a code path nothing currently exercises, I'm happy to trim them down or drop them and keep just the two-line fix.
