### PR TITLE
fix(s3): reject responses with incomplete tags

### DIFF
--- a/gui_agents/s3/utils/formatters.py
+++ b/gui_agents/s3/utils/formatters.py
@@ -39,7 +39,16 @@ CODE_VALID_FORMATTER = lambda agent, obs, response: (
     code_valid_error_msg,
 )
 
-thoughts_answer_tag_check = lambda response: split_thinking_response(response)[1] != ""
+
+def thoughts_answer_tag_check(response):
+    tags = ("<thoughts>", "</thoughts>", "<answer>", "</answer>")
+    tag_positions = [response.find(tag) for tag in tags]
+    if -1 in tag_positions or tag_positions != sorted(tag_positions):
+        return False
+
+    return split_thinking_response(response)[1] != ""
+
+
 thoughts_answer_tag_error_msg = "Incorrect response: The response must contain both <thoughts>...</thoughts> and <answer>...</answer> tags."
 THOUGHTS_ANSWER_TAG_FORMATTER = lambda response: (
     thoughts_answer_tag_check(response),

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,29 @@
+import unittest
+
+from gui_agents.s3.utils.formatters import THOUGHTS_ANSWER_TAG_FORMATTER
+
+
+class TestThoughtsAnswerFormatter(unittest.TestCase):
+    def test_rejects_incomplete_tags(self):
+        responses = [
+            "plain response",
+            "<thoughts>reasoning</thoughts>answer",
+            "reasoning<answer>answer</answer>",
+        ]
+
+        for response in responses:
+            with self.subTest(response=response):
+                success, _ = THOUGHTS_ANSWER_TAG_FORMATTER(response)
+
+                self.assertFalse(success)
+
+    def test_accepts_complete_tags(self):
+        success, _ = THOUGHTS_ANSWER_TAG_FORMATTER(
+            "<thoughts>reasoning</thoughts><answer>answer</answer>"
+        )
+
+        self.assertTrue(success)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes: BehaviorNarrator accepts plain text or a response missing either the thoughts or answer tag pair, so call_llm_formatted skips its corrective retry and malformed caption data reaches bBoN trajectory comparison.
- Root cause: split_thinking_response uses the last split segment when a tag is absent, which makes the full untagged response look like parsed thoughts and answer text; thoughts_answer_tag_check only checked that the parsed thoughts value was nonempty instead of verifying that all four tags exist in order.

## Regression evidence

- Before: `UV_CACHE_DIR=/tmp/agent-s-python311.20260821T160739Z/cache uv run --python 3.11 --no-project --with pillow -- python -m unittest discover -s tests -p 'test_formatters.py' -v` exited `1`

- After: `UV_CACHE_DIR=/tmp/agent-s-python311.20260821T160739Z/cache uv run --python 3.11 --no-project --with pillow -- python -m unittest discover -s tests -p 'test_formatters.py' -v` exited `0`

## Verification

- `UV_CACHE_DIR=/tmp/agent-s-python311.20260821T160739Z/cache uv run --python 3.11 --no-project --with pillow --with numpy --with backoff --with openai --with anthropic -- python -m unittest discover -s tests -v`
- `UV_CACHE_DIR=/tmp/agent-s-python311.20260821T160739Z/cache uv run --python 3.11 --no-project --with black -- black --check gui_agents tests/test_formatters.py`

## Scope

- 2 files changed, +39 / -1 lines
