### PR TITLE
fix: correct typo 'Knowledege' to 'Knowledge' in s1/README.md

### DIFF
--- a/gui_agents/s1/README.md
+++ b/gui_agents/s1/README.md
@@ -200,7 +200,7 @@ exec(action[0])
 
 Refer to `cli_app.py` for more details on how the inference loop works.
 
-#### Downloading the Knowledege Base
+#### Downloading the Knowledge Base
 
 Agent S2 uses a knowledge base that continually updates with new knowledge during inference. The knowledge base is initially downloaded when initializing `GraphSearchAgent`. The knowledge base is stored as assets under our [GitHub Releases](https://github.com/simular-ai/Agent-S/releases). The `GraphSearchAgent` initialization will only download the knowledge base for your specified platform and agent version (e.g s1, s2). If you'd like to download the knowledge base programmatically, you can use the following code:
 


### PR DESCRIPTION
Fix typo in gui_agents/s1/README.md: 'Knowledege Base' → 'Knowledge Base'